### PR TITLE
fix(http/response): Don't write body on HEAD request

### DIFF
--- a/src/s_exp/hirundo/http/response.clj
+++ b/src/s_exp/hirundo/http/response.clj
@@ -33,10 +33,12 @@
   [^ServerResponse server-response {:as response :keys [body headers status]}]
   (set-headers! server-response headers)
   (set-status! server-response status)
-  (write-body! server-response response body))
+  (if body
+    (write-body! server-response response body)
+    (.send server-response)))
 
 (defn set-head-response!
-  [^ServerResponse server-response {:as response :keys [headers status]}]
+  [^ServerResponse server-response {:keys [headers status]}]
   (set-headers! server-response headers)
   (set-status! server-response status)
   (.send server-response))

--- a/src/s_exp/hirundo/http/response.clj
+++ b/src/s_exp/hirundo/http/response.clj
@@ -34,3 +34,9 @@
   (set-headers! server-response headers)
   (set-status! server-response status)
   (write-body! server-response response body))
+
+(defn set-head-response!
+  [^ServerResponse server-response {:as response :keys [headers status]}]
+  (set-headers! server-response headers)
+  (set-status! server-response status)
+  (.send server-response))

--- a/src/s_exp/hirundo/http/routing.clj
+++ b/src/s_exp/hirundo/http/routing.clj
@@ -19,10 +19,12 @@
         (into-array Handler
                     [(reify Handler
                        (handle [_ server-request server-response]
-                         (let [response (handler (request/ring-request server-request server-response))]
+                         (let [response (handler (request/ring-request server-request server-response))
+                               head? (= (.method (.prologue server-request)) io.helidon.http.Method/HEAD)]
                            (cond->> response
                              (map? response)
-                             (response/set-response! server-response)))))]))))))
+                             ((if head? response/set-head-response! response/set-response!)
+                              server-response)))))]))))))
 
 (defmethod options/set-server-option! :http-handler
   [^WebServerConfig$Builder builder _ handler options]

--- a/test/s_exp/hirundo_test.clj
+++ b/test/s_exp/hirundo_test.clj
@@ -85,7 +85,10 @@
     (is (-> (client/get *endpoint*) :body (= "yes"))))
 
   (with-server {:http-handler (fn [req] {:body (java.io.ByteArrayInputStream. (.getBytes "yes"))})}
-    (is (-> (client/get *endpoint*) :body (= "yes")))))
+    (is (-> (client/get *endpoint*) :body (= "yes"))))
+
+  (with-server {:http-handler (fn [req] {:body (java.io.ByteArrayInputStream. (.getBytes "yes"))})}
+    (is (-> (client/head *endpoint*) :body nil?))))
 
 (deftest resp-map-decoding
   (with-server {:http-handler (fn [req]


### PR DESCRIPTION
RFC 9110 8.6 contains the following paragraph:

"A server MAY send a Content-Length header field in a response to a HEAD request (Section 9.3.2); a server MUST NOT send Content-Length in such a response unless its field value equals the decimal number of octets that would have been sent in the content of a response if the same request had used the GET method."

When writing a nil body and closing the output stream, Helidon recomputes the length of the body bytes and overwrites any content-length header provided. In the case of a HEAD request, where a content-length header may be provided but where there is no body, this causes the content-length to be reset to 0.

This commit adds a special set-head-response! function that avoids writing the body, and calls send() on the server-response instead, as required by Helidon, see
https://helidon.io/docs/v4/se/webserver/webserver#anchor-sending-response

Fixes #33 